### PR TITLE
设置翻译值时，增加索引和数组长度对比，避免超出数组长度导致闪退

### DIFF
--- a/LanguageTool/Utilities/LocalizationJSONGenerator.swift
+++ b/LanguageTool/Utilities/LocalizationJSONGenerator.swift
@@ -67,7 +67,8 @@ class LocalizationJSONGenerator {
                             stringsDict[key] = ["localizations": [:]]
                         }
                         if var localizations = stringsDict[key] as? [String: Any],
-                           var localizationsDict = localizations["localizations"] as? [String: Any] {
+                           var localizationsDict = localizations["localizations"] as? [String: Any],
+                           index < translations.count {
                             localizationsDict[language] = [
                                 "stringUnit": [
                                     "state": "translated",


### PR DESCRIPTION
解决了下图闪退的情况
![Pasted Graphic](https://github.com/user-attachments/assets/672466b7-6c72-4fb0-a694-ad7e910e15b7)
